### PR TITLE
API for payment requests without tokens

### DIFF
--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -62,19 +62,19 @@ components:
         trustedAnchorName:
           type: string
 
-    TokenPaymentData:
+    PaymentToken:
       type: object
       required:
-        - tokenPan
-        - tokenPsn
-        - tokenExpiryDate
+        - pan
+        - psn
+        - expiryDate
       properties:
-        tokenPan:
-          $ref: '#/components/schemas/tokenPan'
-        tokenPsn:
-          $ref: '#/components/schemas/tokenPsn'
-        tokenExpiryDate:
-          $ref: '#/components/schemas/tokenExpiryDate'
+        pan:
+          $ref: '#/components/schemas/pan'
+        psn:
+          $ref: '#/components/schemas/psn'
+        expiryDate:
+          $ref: '#/components/schemas/expiryDate'
 
     paymentId:
       type: string
@@ -103,24 +103,24 @@ components:
         A unique identifier that guarantees message idempotency.
       type: string
       example: "74313af1-e2cc-403f-85f1-6050725b01b6"
-    tokenPan:
+    pan:
       type: string
       pattern: '^[0-9]{19}$'
       example: '9578540012345678901'
       description: >-
-        The tokenized PAN of the payment card.
-    tokenPsn:
+        The PAN of the payment token.
+    psn:
       type: string
       pattern: '^[0-9]{1,3}$'
       example: '0'
       description: >-
-        The tokenized PAN Sequence Number of the payment card.
-    tokenExpiryDate:
+        The PAN Sequence Number of the payment token.
+    expiryDate:
       type: string
       pattern: '^[0-9]{2}(0[1-9]|1[0-2])$'
       example: '2108'
       description: >-
-        The expiration date of the token (YYMM).
+        The expiration date of the payment token (YYMM).
     tokenRequestorId:
       type: string
       pattern: "^[0-9]{1,11}$"

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -344,7 +344,7 @@ components:
         - verifiedCardholderAuthenticationSignedData
       properties:
         paymentToken:
-          $ref: '../components.yaml#/components/schemas/TokenPaymentData'
+          $ref: '../components.yaml#/components/schemas/PaymentToken'
         verifiedCardholderAuthenticationSignedData:
           $ref: '../components.yaml#/components/schemas/verifiedCardholderAuthenticationSignedData'
 

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -445,11 +445,14 @@ components:
       required:
         - tokenRequestorId
         - tokenId
+        - nin
       properties:
         tokenRequestorId:
           $ref: '../components.yaml#/components/schemas/tokenRequestorId'
         tokenId:
           $ref: '../components.yaml#/components/schemas/tokenId'
+        nin:
+          $ref: '../components.yaml#/components/schemas/nin'
     merchantAggregatorId:
       type: string
       maxLength: 36

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -279,7 +279,6 @@ components:
       type: object
       required:
         - amount
-        - encryptedCardholderAuthenticationData
         - merchantAggregatorId
         - merchantId
         - merchantName
@@ -300,6 +299,8 @@ components:
           example: false
         encryptedCardholderAuthenticationData:
           $ref: '#/components/schemas/encryptedPaymentCardholderAuthenticationData'
+        paymentTokenId:
+          $ref: '../components.yaml#/components/schemas/tokenId'
         merchantAggregatorId:
           $ref: '#/components/schemas/merchantAggregatorId'
         merchantId:

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -299,8 +299,8 @@ components:
           example: false
         encryptedCardholderAuthenticationData:
           $ref: '#/components/schemas/encryptedPaymentCardholderAuthenticationData'
-        paymentTokenId:
-          $ref: '../components.yaml#/components/schemas/tokenId'
+        cardholderData:
+          $ref: '#/components/schemas/cardholderData'
         merchantAggregatorId:
           $ref: '#/components/schemas/merchantAggregatorId'
         merchantId:
@@ -440,6 +440,16 @@ components:
       description: >-
         The Payment and Cardholder Authentication Data is encrypted according to the Java Web Encryption specification defined in RFC-7516.
         See schema PaymentCardholderAuthenticationData for decrypted data format
+    cardholderData:
+      type: object
+      required:
+        - tokenRequestorId
+        - tokenId
+      properties:
+        tokenRequestorId:
+          $ref: '../components.yaml#/components/schemas/tokenRequestorId'
+        tokenId:
+          $ref: '../components.yaml#/components/schemas/tokenId'
     merchantAggregatorId:
       type: string
       maxLength: 36

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -445,14 +445,11 @@ components:
       required:
         - tokenRequestorId
         - tokenId
-        - nin
       properties:
         tokenRequestorId:
           $ref: '../components.yaml#/components/schemas/tokenRequestorId'
         tokenId:
           $ref: '../components.yaml#/components/schemas/tokenId'
-        nin:
-          $ref: '../components.yaml#/components/schemas/nin'
     merchantAggregatorId:
       type: string
       maxLength: 36

--- a/openapi/integrator/token-requestor/client.yaml
+++ b/openapi/integrator/token-requestor/client.yaml
@@ -169,7 +169,7 @@ components:
         tokenRequestorId:
           $ref: '../components.yaml#/components/schemas/tokenRequestorId'
         paymentToken:
-          $ref: '../components.yaml#/components/schemas/TokenPaymentData'
+          $ref: '../components.yaml#/components/schemas/PaymentToken'
         accountNumberLastFourDigits:
           type: string
           pattern: '^[0-9]{4}$'
@@ -210,4 +210,4 @@ components:
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
         tokenExpiryDate:
-          $ref: '../components.yaml#/components/schemas/tokenExpiryDate'
+          $ref: '../components.yaml#/components/schemas/expiryDate'

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
         <version>2.7.3</version>
+        <relativePath/>
     </parent>
 
     <modules>


### PR DESCRIPTION
Made `encryptedCardholderAuthenticationData` optional and added `cardholderData` as an alternative. Latter contains the `tokenId` and `tokenRequestorId` only.

Side effect: Renamed `TokenPaymentData` to `PaymentToken` and removed the prefix repetitions on the property names.