### PR TITLE
Merchant notifications do not include merchant reference

### DIFF
--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -82,6 +82,13 @@ components:
       example: "7f60d761-f27d-43d3-8ee9-53881b3c868d"
       description: >-
         The identifier for a specific payment.
+    merchantReference:
+      type: string
+      maxLength: 80
+      description: >-
+        A reference set by the merchant to uniquely identify a payment request.
+        BankAxept uses this reference in all communication with the merchant about the payment status.
+        It is recommended that a unique value per payment is used. However, it is not a requirement.
     batchNumber:
       type: integer
       format: int64

--- a/openapi/integrator/merchant/client.yaml
+++ b/openapi/integrator/merchant/client.yaml
@@ -16,7 +16,7 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: '#/components/schemas/PaymentRequestCallbackData'
+              $ref: '#/components/schemas/PaymentResponse'
       responses:
         '200':
           $ref: '../components.yaml#/components/responses/200Ok'
@@ -33,10 +33,9 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/{paymentId}/captures:
+  /payments/captures:
     description: Payment capture callback
     parameters:
-      - $ref: '../components.yaml#/components/parameters/paymentId'
       - $ref: '../components.yaml#/components/parameters/correlationId'
     post:
       operationId: captureCallback
@@ -45,7 +44,7 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: '#/components/schemas/CaptureCallbackData'
+              $ref: '#/components/schemas/CaptureResponse'
       responses:
         '200':
           $ref: '../components.yaml#/components/responses/200Ok'
@@ -74,7 +73,7 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: '#/components/schemas/RefundCallbackData'
+              $ref: '#/components/schemas/RefundResponse'
       responses:
         '200':
           $ref: '../components.yaml#/components/responses/200Ok'
@@ -120,19 +119,22 @@ paths:
 
 components:
   schemas:
-    PaymentRequestCallbackData:
+    PaymentResponse:
       type: object
       required:
-        - paymentId
         - messageId
-        - code
+        - paymentId
+        - merchantReference
+        - status
       properties:
-        paymentId:
-          $ref: '../components.yaml#/components/schemas/paymentId'
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
-        code:
-          $ref: '#/components/schemas/PaymentRequestCode'
+        paymentId:
+          $ref: '../components.yaml#/components/schemas/paymentId'
+        merchantReference:
+          $ref: '../components.yaml#/components/schemas/merchantReference'
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
         authorisationCode:
           type: string
           description: >-
@@ -140,11 +142,11 @@ components:
         batchNumber:
           $ref: '../components.yaml#/components/schemas/batchNumber'
 
-    PaymentRequestCode:
+    PaymentStatus:
       type: string
       example: Accepted
       description: |
-        Code specifying the result of the operation:
+        Status code specifying the result of the operation:
         * AuthorisationApproved - Payment was authorised.
         * Rejected - Payment request was rejected.
         * RolledBack - Payment request was rolled back.
@@ -161,41 +163,51 @@ components:
         - AuthorisationFailed
         - AuthorisationDeclined
 
-    CaptureCallbackData:
+    CaptureResponse:
       type: object
       required:
-        - code
+        - messageId
+        - paymentId
+        - merchantReference
+        - status
       properties:
-        code:
-          $ref: '#/components/schemas/CaptureCode'
+        messageId:
+          $ref: '../components.yaml#/components/schemas/messageId'
+        paymentId:
+          $ref: '../components.yaml#/components/schemas/paymentId'
+        merchantReference:
+          $ref: '../components.yaml#/components/schemas/merchantReference'
+        status:
+          $ref: '#/components/schemas/CaptureStatus'
         timeCreated:
           type: string
           format: date-time
           description: >-
             The time and date the request was created. The date fields use the YYYY-MM-DDThh:mm:ss.sssZ date ISO 8601 format. Times are returned in the UTC time zone.
-        captureId:
-          type: string
-          description: >-
-            The /capture request id. This is ePayment platform's reference associated with this /capture request.
         batchNumber:
           $ref: '../components.yaml#/components/schemas/batchNumber'
 
-    RefundCallbackData:
+    RefundResponse:
       type: object
       required:
-        - code
+        - messageId
+        - paymentId
+        - merchantReference
+        - status
       properties:
-        code:
-          $ref: '#/components/schemas/RefundCode'
+        messageId:
+          $ref: '../components.yaml#/components/schemas/messageId'
+        paymentId:
+          $ref: '../components.yaml#/components/schemas/paymentId'
+        merchantReference:
+          $ref: '../components.yaml#/components/schemas/merchantReference'
+        status:
+          $ref: '#/components/schemas/RefundStatus'
         timeCreated:
           type: string
           format: date-time
           description: >-
             The time and date the request was created. The date fields use the YYYY-MM-DDThh:mm:ss.sssZ date ISO 8601 format. Times are returned in the UTC time zone.
-        refundId:
-          type: string
-          description: >-
-            The /refund request id. This is ePayment platform's reference associated with this /refund request.
         batchNumber:
           $ref: '../components.yaml#/components/schemas/batchNumber'
 
@@ -233,7 +245,7 @@ components:
           type: integer
           format: int64
 
-    CaptureCode:
+    CaptureStatus:
       type: string
       example: Approved
       description: |
@@ -244,7 +256,7 @@ components:
         - Approved
         - Declined
 
-    RefundCode:
+    RefundStatus:
       type: string
       example: Approved
       description: |

--- a/openapi/integrator/merchant/client.yaml
+++ b/openapi/integrator/merchant/client.yaml
@@ -6,11 +6,11 @@ info:
 
 paths:
   /payments:
-    description: Payment request callback
+    description: Response to a payment request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'
     post:
-      operationId: paymentRequestCallback
+      operationId: paymentResponse
       requestBody:
         required: true
         content:
@@ -34,11 +34,11 @@ paths:
           $ref: '../components.yaml#/components/responses/503Error'
 
   /payments/captures:
-    description: Payment capture callback
+    description: Response to a capture request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'
     post:
-      operationId: captureCallback
+      operationId: captureResponse
       requestBody:
         required: true
         content:
@@ -62,12 +62,12 @@ paths:
           $ref: '../components.yaml#/components/responses/503Error'
 
   /payments/{paymentId}/refunds:
-    description: Payment refund callback
+    description: Response to a refund request
     parameters:
       - $ref: '../components.yaml#/components/parameters/paymentId'
       - $ref: '../components.yaml#/components/parameters/correlationId'
     post:
-      operationId: refundCallback
+      operationId: refundResponse
       requestBody:
         required: true
         content:
@@ -90,17 +90,17 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
   /settlements:
-    description: Cut-off settlement batch request callback
+    description: Response to a cut-off request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'
     post:
-      operationId: cutOffSettlementBatchCallback
+      operationId: cutOffResponse
       requestBody:
         required: true
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: '#/components/schemas/CutOffCallbackData'
+              $ref: '#/components/schemas/CutOffResponse'
       responses:
         '200':
           $ref: '../components.yaml#/components/responses/200Ok'
@@ -135,8 +135,14 @@ components:
           $ref: '../components.yaml#/components/schemas/merchantReference'
         status:
           $ref: '#/components/schemas/PaymentStatus'
+        authenticationBindingMessage:
+          type: string
+          maxLength: 80
+          description: >-
+            Binding message for the cardholder authentication.
         authorisationCode:
           type: string
+          maxLength: 6
           description: >-
             Authorisation code: When the payment is authorised successfully, this field holds the authorisation code for the payment. When the payment is not authorised, this field is empty.
         batchNumber:
@@ -147,6 +153,7 @@ components:
       example: Accepted
       description: |
         Status code specifying the result of the operation:
+        * Authenticating - Cardholder authentication in progress.
         * AuthorisationApproved - Payment was authorised.
         * Rejected - Payment request was rejected.
         * RolledBack - Payment request was rolled back.
@@ -155,6 +162,7 @@ components:
         * AuthorisationFailed - Payment authorisation failed.
         * AuthorisationDeclined - Payment authorisation was declined.
       enum:
+        - Authenticating
         - AuthorisationApproved
         - Rejected
         - RolledBack
@@ -211,7 +219,7 @@ components:
         batchNumber:
           $ref: '../components.yaml#/components/schemas/batchNumber'
 
-    CutOffCallbackData:
+    CutOffResponse:
       type: object
       properties:
         batchNumber:

--- a/openapi/integrator/merchant/client.yaml
+++ b/openapi/integrator/merchant/client.yaml
@@ -61,10 +61,9 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/{paymentId}/refunds:
+  /payments/refunds:
     description: Response to a refund request
     parameters:
-      - $ref: '../components.yaml#/components/parameters/paymentId'
       - $ref: '../components.yaml#/components/parameters/correlationId'
     post:
       operationId: refundResponse

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -320,7 +320,7 @@ components:
             A merchant-supplied message about the payment/order. The maximum length is 50 characters. Allowed characters are the letters a-å, A-Å, the numbers 0-9 and the special characters :;.,?!()".
           example: "Airline ticket 912-783248767327476"
         merchantReference:
-          $ref: '#/components/schemas/merchantReference'
+          $ref: '../components.yaml#/components/schemas/merchantReference'
         merchantCategoryCode:
           type: string
           pattern: '^[0-9]{4}$'
@@ -466,14 +466,6 @@ components:
       description: >-
         The merchant's name, as shown to the cardholder, on receipts and on bank statements.
         This must be the exact string that was entered with the merchant enrollment.
-    merchantReference:
-      type: string
-      maxLength: 80
-      description: >-
-        A reference set by the merchant to uniquely identify a request.
-        BankAxept uses this reference in all communication with the merchant about the payment status.
-        It is recommended that a unique value per payment is used.
-        However, it is not a requirement.
     merchantLocation:
       type: object
       required:


### PR DESCRIPTION
Adding merchantReference for all responses (callbacks) from ePayment Initiator's merchant API.

Side effects:
Renamed the endpoints and objects from "request callback" to "response".