### PR TITLE
Upgrade to Spring Boot 3.0.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ steps:
     mavenPomFile: 'pom.xml'
     mavenOptions: '-Xmx3072m'
     javaHomeOption: 'JDKVersion'
-    jdkVersionOption: '1.11'
+    jdkVersionOption: '1.17'
     jdkArchitectureOption: 'x64'
     publishJUnitResults: true
     testResultsFiles: '**/surefire-reports/TEST-*.xml'

--- a/java/client-test/pom.xml
+++ b/java/client-test/pom.xml
@@ -37,8 +37,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.32.0</version>
+            <artifactId>wiremock-jre8-standalone</artifactId>
+            <version>2.35.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/client-test/src/test/java/no/bankaxept/epayment/test/client/webflux/WebFluxBaseClientTest.java
+++ b/java/client-test/src/test/java/no/bankaxept/epayment/test/client/webflux/WebFluxBaseClientTest.java
@@ -1,25 +1,30 @@
 package no.bankaxept.epayment.test.client.webflux;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.forbidden;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.removeStub;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.matching.EqualToPattern;
-import no.bankaxept.epayment.client.base.BaseClient;
-import no.bankaxept.epayment.test.client.AbstractBaseClientWireMockTest;
 import no.bankaxept.epayment.client.base.AccessFailed;
 import no.bankaxept.epayment.client.base.http.HttpResponse;
 import no.bankaxept.epayment.client.base.http.HttpStatus;
 import no.bankaxept.epayment.client.base.http.HttpStatusException;
-import org.junit.jupiter.api.*;
+import no.bankaxept.epayment.test.client.AbstractBaseClientWireMockTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import reactor.adapter.JdkFlowAdapter;
 import reactor.test.StepVerifier;
-
-import java.util.List;
-import java.util.Map;
-
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class WebFluxBaseClientTest extends AbstractBaseClientWireMockTest {
 
@@ -52,7 +57,7 @@ public class WebFluxBaseClientTest extends AbstractBaseClientWireMockTest {
             stubFor(tokenEndpointMapping(forbidden()));
             baseClient = createScheduledBaseClient(wmRuntimeInfo.getHttpPort());
             assertThatThrownBy(() -> baseClient.post("/test", emptyPublisher(), "1")).isInstanceOf(AccessFailed.class)
-                    .getCause().isInstanceOf(HttpStatusException.class)
+                    .cause().isInstanceOf(HttpStatusException.class)
                     .hasFieldOrPropertyWithValue("HttpStatus", new HttpStatus(403));
         }
 
@@ -68,7 +73,7 @@ public class WebFluxBaseClientTest extends AbstractBaseClientWireMockTest {
             stubFor(tokenEndpointMapping(serverError()));
             baseClient = createScheduledBaseClient(wmRuntimeInfo.getHttpPort());
             assertThatThrownBy(() -> baseClient.post("/test", emptyPublisher(), "1")).isInstanceOf(AccessFailed.class)
-                    .getCause().isInstanceOf(HttpStatusException.class)
+                    .cause().isInstanceOf(HttpStatusException.class)
                     .hasFieldOrPropertyWithValue("HttpStatus", new HttpStatus(500));
             removeStub(tokenEndpointMapping(serverError()));
             stubFor(tokenEndpointMapping(validTokenResponse()));

--- a/java/merchant-client/pom.xml
+++ b/java/merchant-client/pom.xml
@@ -19,10 +19,6 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/java/merchant-client/pom.xml
+++ b/java/merchant-client/pom.xml
@@ -19,6 +19,10 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -33,6 +37,7 @@
                         </goals>
                         <configuration>
                             <configOptions>
+                                <useJakartaEe>true</useJakartaEe>
                                 <booleanGetterPrefix>is</booleanGetterPrefix>
                                 <dateLibrary>java8</dateLibrary>
                                 <hideGenerationTimestamp>true</hideGenerationTimestamp>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,6 +25,10 @@
                     <artifactId>openapi-generator-maven-plugin</artifactId>
                     <version>6.2.1</version>
                 </plugin>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
+                    </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,10 +25,6 @@
                     <artifactId>openapi-generator-maven-plugin</artifactId>
                     <version>6.2.1</version>
                 </plugin>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
-                    </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -66,8 +66,8 @@
         </dependencies>
     </dependencyManagement>
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <swagger.parser.version>2.0.30</swagger.parser.version>
         <!-- Override the netty version spring boot uses with the version used by com.azure packages -->
         <netty.version>4.1.82.Final</netty.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -25,6 +25,20 @@
                     <artifactId>openapi-generator-maven-plugin</artifactId>
                     <version>6.2.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                    <configuration>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.ow2.asm</groupId>
+                            <artifactId>asm</artifactId>
+                            <version>9.1</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -66,8 +80,6 @@
         </dependencies>
     </dependencyManagement>
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <swagger.parser.version>2.0.30</swagger.parser.version>
         <!-- Override the netty version spring boot uses with the version used by com.azure packages -->
         <netty.version>4.1.82.Final</netty.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,6 +31,8 @@
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                     </configuration>
+                    <!--As of surefire v.2.22.2, its plexus-java dependency was transitively pulling an older
+                    version of asm 6.2 that did not support Java 17, requiring us to manually provide the version.-->
                     <dependencies>
                         <dependency>
                             <groupId>org.ow2.asm</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,7 +23,7 @@
                 <plugin>
                     <groupId>org.openapitools</groupId>
                     <artifactId>openapi-generator-maven-plugin</artifactId>
-                    <version>5.4.0</version>
+                    <version>6.2.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/java/token-requestor-client/pom.xml
+++ b/java/token-requestor-client/pom.xml
@@ -19,10 +19,6 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/java/token-requestor-client/pom.xml
+++ b/java/token-requestor-client/pom.xml
@@ -19,6 +19,10 @@
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -33,6 +37,7 @@
                         </goals>
                         <configuration>
                             <configOptions>
+                                <useJakartaEe>true</useJakartaEe>
                                 <booleanGetterPrefix>is</booleanGetterPrefix>
                                 <dateLibrary>java8</dateLibrary>
                                 <hideGenerationTimestamp>true</hideGenerationTimestamp>

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -356,13 +356,13 @@ components:
           type: string
           pattern: '^[0-9]{4}$'
         amount:
-          $ref: '#/components/schemas/Amount'
+          $ref: '../components.yaml#/components/schemas/Amount'
         merchantName:
           $ref: '#/components/schemas/merchantName'
         merchantDisplayName:
           $ref: '#/components/schemas/merchantDisplayName'
         merchantReference:
-          $ref: '#/components/schemas/merchantReference'
+          $ref: '../components.yaml#/components/schemas/merchantReference'
 
     CaptureRequest:
       type: object

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>2.7.3</version>
+        <version>3.0.1</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Bumping spring boot to 3.0.1. Have to use java 17 since that's the minimum version spring boot 3 is supporting. Client /java generation with openapi still annotates with javax.* and not jakarta, but it seems to work fine nevertheless? Think this is fixed in newer versions of openapi-generator, so we should remember to upgrade. 