### PR TITLE
Verified Cardholder Authentication Signed Data as JWT

### DIFF
--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -66,19 +66,15 @@ components:
           enum:
             - payment.v1
             - approveAccount.v1
-        #authenticationDateTime
-        #verificationDateTime
         iat:
           type: integer
           minimum: 1600000000
           maximum: 1800000000
-        #authenticationCredentialsSet.authenticationProviderId
         iss:
           type: string
         nonce:
           type: string
           description: The nonce from the permission statement
-        #nin
         sub:
           type: string
           description: |
@@ -86,17 +82,14 @@ components:
             The syntax is "identifierType:identifierValue". For
             NNINs, the identifierType is "nnin".
           example: "nnin:010112345"
-        #authenticationReference
         permissionId:
           type: string
           description: Unique id of the permission request
-        #authenticatedData
         digest:
           type: string
           format: bytes
           description: |
             The digest of the permission statement (URL-safe Base64-encoded SHA-256 hash of the permission statement bytes)
-        #authenticationCredentialsSet.trustedAnchorName
         mostRecentTrustAnchorAuthentication:
           $ref: '#/components/schemas/PermissionGrant'
 

--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -90,8 +90,6 @@ components:
           format: bytes
           description: |
             The digest of the permission statement (URL-safe Base64-encoded SHA-256 hash of the permission statement bytes)
-        mostRecentTrustAnchorAuthentication:
-          $ref: '#/components/schemas/PermissionGrant'
 
     Nonce:
       type: string

--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -39,20 +39,6 @@ components:
         cashback:
           $ref: '#/components/schemas/Amount'
 
-    MostRecentTrustAnchorAuthentication:
-      type: object
-      required:
-        - authenticationDateTime
-        - authenticationReference
-        - authenticationCredentialsSet
-      properties:
-        authenticationDateTime:
-          $ref: '#/components/schemas/authenticationDateTime'
-        authenticationReference:
-          $ref: '#/components/schemas/authenticationReference'
-        authenticationCredentialsSet:
-          $ref: '#/components/schemas/AuthenticationCredentialsSet'
-
     encryptedPaymentCardholderAuthenticationData:
       type: string
       example: "eyJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYWxnIjoiUlNBLU9BRVAtMjU2In0.f5nkE6FuGYkoa4usRQ1MhUJY34pYi31xgSiApiR1uP4tSXV3DNnY3N5Zq9Bnt1OucN2nJxAqCcND4G8TpGw9kofFcLcs5kXHg7nmIgjI8ZXTYx7GuZ_w6YxVTzCmjT5dpSlOQFkuCfJn2VdKnF4PjaqiKW9fWluOKorUZdsjsDl5PjIjf3ndqCtGEma6TBpKxLX0FnCZzvsVATCBcxqwKLvkAYFdFFtLfxe5OvW0PFsy4OjasODW3Kk55e58v5xXB8bP9hzr5S7sXFlzX2TG583MLLXG3K1E3XG0R262vs2cGgSA1B6zmujvmkpR4lLofwgahpO-ZrhGZtXE0-wFJw.NDB8Ln7XCf1q1p6ddRvnSw.PTBsKUkN5stmSQwrQ-jQLA.ece3W1q3AiMdg5QQbAd1tq_nQWLRkyNnk2mL1TP8fpQ"
@@ -71,58 +57,144 @@ components:
         verifiedCardholderAuthenticationSignedData:
           $ref: '#/components/schemas/verifiedCardholderAuthenticationSignedData'
 
-    VerifiedCardholderPaymentAuthenticationData:
+    PermissionGrant:
       type: object
-      required:
-        - authenticatedData
-        - nin
-        - authenticationReference
-        - authenticationCredentialsSet
-        - verificationDateTime
       properties:
-        authenticatedData:
-          $ref: '#/components/schemas/PaymentAuthenticatedData'
-        nin:
-          $ref: '#/components/schemas/nin'
-        authenticationReference:
-          $ref: '#/components/schemas/authenticationReference'
-        authenticationCredentialsSet:
-          $ref: '#/components/schemas/AuthenticationCredentialsSet'
-        authenticationDateTime:
-          $ref: '#/components/schemas/authenticationDateTime'
-        verificationDateTime:
+        type:
           type: string
-          format: date-time
+          description: Type of the permission statement.
+          enum:
+            - payment.v1
+            - approveAccount.v1
+        #authenticationDateTime
+        #verificationDateTime
+        iat:
+          type: integer
+          minimum: 1600000000
+          maximum: 1800000000
+        #authenticationCredentialsSet.authenticationProviderId
+        iss:
+          type: string
+        nonce:
+          type: string
+          description: The nonce from the permission statement
+        #nin
+        sub:
+          type: string
+          description: |
+            The primary identifier of the subject that granted the permission.
+            The syntax is "identifierType:identifierValue". For
+            NNINs, the identifierType is "nnin".
+          example: "nnin:010112345"
+        #authenticationReference
+        permissionId:
+          type: string
+          description: Unique id of the permission request
+        #authenticatedData
+        digest:
+          type: string
+          format: bytes
+          description: |
+            The digest of the permission statement (URL-safe Base64-encoded SHA-256 hash of the permission statement bytes)
+        #authenticationCredentialsSet.trustedAnchorName
         mostRecentTrustAnchorAuthentication:
-          $ref: '#/components/schemas/MostRecentTrustAnchorAuthentication'
+          $ref: '#/components/schemas/PermissionGrant'
 
-    PaymentAuthenticatedData:
+    Nonce:
+      type: string
+      minLength: 16
+      maxLength: 64
+      example: -MEDBtU6SeGtFsdHHI-rlA
+
+    BasePermission:
       type: object
       required:
-        - accountNumberLastFourDigits
-        - amount
-        - merchantName
+        - nonce
       properties:
-        accountNumberLastFourDigits:
-          type: string
-          pattern: '^[0-9]{4}$'
-        amount:
-          $ref: '#/components/schemas/Amount'
-        merchantName:
-          $ref: '#/components/schemas/merchantName'
-        merchantDisplayName:
-          $ref: '#/components/schemas/merchantDisplayName'
-        merchantReference:
-          $ref: '#/components/schemas/merchantReference'
+        nonce:
+          $ref: "#/components/schemas/Nonce"
 
-    AuthenticationCredentialsSet:
+    ApproveAccountPermissionV1:
+      allOf:
+        - $ref: "#/components/schemas/BasePermission"
+        - type: object
+          required:
+            - accountNumber
+            - merchantName
+          properties:
+            accountNumber:
+              description: Account number
+              type: string
+              pattern: "^[0-9]{11}$"
+              example: "12341212345"
+            merchantName:
+              type: string
+              description: The Merchant where the card will be approved
+              maxLength: 70
+
+    PaymentBasePermissionV1:
+      description: |
+        This must satisfy PSD2 RTS Article 4 Authentication code and
+        Article 5 Dynamic Linking
       type: object
+      required:
+        - paymentId
+        - amount
+        - currency
+        - creditorName
       properties:
-        authenticationProviderId:
+        paymentId:
           type: string
-          pattern: '^[0-9]{4}$'
-        trustedAnchorName:
+          description: |
+            Payment id used for lookup at ASPSP.
+            Payment id is not displayed to the user.
+          example: Gm1rYOxUyzBQ03BLgr_EpEXq5HTwm-K-uUMroUNlRpI=
+        amount:
+          description: |
+            The amount given with fractional digits, where fractions must be compliant to the currency definition.
+            Up to 14 significant figures. Negative amounts are signed by minus.
+            The decimal separator is a dot.
+            **Example:**
+            Valid representations for EUR with up to two decimals are:
+              * 1056
+              * 5768.2
+              * -1.50
+              * 5877.78
           type: string
+          pattern: "-?[0-9]{1,14}(\\.[0-9]{1,3})?"
+          example: "5877.78"
+        currency:
+          type: string
+          description: |
+            ISO 4217 Alpha 3 currency code.
+          minLength: 3
+          maxLength: 3
+          pattern: "[A-Z]{3}"
+          example: "NOK"
+        creditorName:
+          $ref: '#/components/schemas/merchantDisplayName'
+
+    PaymentPermissionV1:
+      description: |
+        This must satisfy PSD2 RTS Article 4 Authentication code and
+        Article 5 Dynamic Linking
+      allOf:
+        - $ref: "#/components/schemas/BasePermission"
+        - type: object
+          required:
+            - id
+            - payments
+          properties:
+            id:
+              type: string
+              description: |
+                Payment or basket id used for lookup at ASPSP.
+                The user does not approve the id itself or anything implicitly inferred from the id.
+              example: 1234-basket-567
+            payments:
+              type: array
+              items:
+                $ref: "#/components/schemas/PaymentBasePermissionV1"
 
     PaymentToken:
       type: object
@@ -229,8 +301,8 @@ components:
       type: string
       example: "eyJhbGciOiJSUzI1NiIsIng1dCNTMjU2IjoiZGlnZXN0KGNlcnQpIn0.eyJhdXRoZW50aWNhdGVkRGF0YSI6eyJhY2NvdW50TnVtYmVyIjoiOTk5Nzc1MTIzNDUiLCJ0b2tlblJlcXVlc3Rvck5hbWUiOiJ0b2tlblJlcXVlc3Rvck5hbWUifSwibmluIjoiMTMwODc1MTIzNDUiLCJhdXRoZW50aWNhdGlvblNkbyI6Ijg0MzEzYWYxLWUyY2MtNDAzZi04NWYxLTYwNTA3MjViMDFiNiIsImF1dGhlbnRpY2F0aW9uQ3JlZGVudGlhbHNTZXQiOiJCQU5LSUQiLCJhdXRoZW50aWNhdGlvbkRhdGVUaW1lIjoiMjAxNy0wNy0yMVQxNzozMjoyOFoiLCJ2ZXJpZmljYXRpb25EYXRlVGltZSI6IjIwMTctMDctMjFUMTc6MzI6NDJaIn0.UoRYvKtrZrojIaq4P_iHjfA5Hx9SkEL-v_U0WMv78urpMbqsH2EpBdMuervwNWJKhc5vSp7ugO9LFYgE1PzSDUOYrMa6HfCJeRjlcgRODPC_exrX5lflUr7c-B8MJwSidCkOaKekrYexskYFpk4sdRTizbFdERzr3ZkgvBs_oa22KTYMwpipFO8i-Yf5XEE4zHGvh8abOsIY1yQQGhMwgr9RjNh_bi1wqL_FTJRPggsPjBMxrneWgy2veUbhHUq_JYqvSQxvhhJ_1RdE4gHXz0xaptmmbdZ5mtI1DyCRJEn6Io4x-0VIssApvljPjsMylcG2moeIDqUbjUAfxGrZcA"
       description: >-
-        The Verified Cardholder Authentication Data is signed in JWS Compact Serialisation format according to the Java Web Signature specification defined in RFC-7515.
-        See schema VerifiedCardholderEnrolmentAuthenticationData and VerifiedCardholderPaymentAuthenticationData for payload format.
+        The Verified Cardholder Authentication Data is a signed JWT in JWS Compact Serialisation format according to the
+        Java Web Signature specification defined in RFC-7515. See schema PermissionGrant for payload format.
     nin:
       type: string
       pattern: '^[0-9]{11}$'

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -312,9 +312,6 @@ components:
     PaymentCardholderAuthenticationData:
       $ref: '../components.yaml#/components/schemas/PaymentCardholderAuthenticationData'
 
-    VerifiedCardholderPaymentAuthenticationData:
-      $ref: '../components.yaml#/components/schemas/VerifiedCardholderPaymentAuthenticationData'
-
     CaptureRequest:
       type: object
       required:

--- a/openapi/integrator/merchant/server.yaml
+++ b/openapi/integrator/merchant/server.yaml
@@ -312,6 +312,9 @@ components:
     PaymentCardholderAuthenticationData:
       $ref: '../components.yaml#/components/schemas/PaymentCardholderAuthenticationData'
 
+    PermissionGrant:
+      $ref: '../components.yaml#/components/schemas/PermissionGrant'
+
     CaptureRequest:
       type: object
       required:

--- a/openapi/integrator/token-requestor/server.yaml
+++ b/openapi/integrator/token-requestor/server.yaml
@@ -96,6 +96,9 @@ components:
         cardholderAuthenticationData:
           $ref: '#/components/schemas/CardholderAuthenticationData'
 
+    PermissionGrant:
+      $ref: '../components.yaml#/components/schemas/PermissionGrant'
+
     EnrolmentData:
       type: object
       required:

--- a/openapi/integrator/token-requestor/server.yaml
+++ b/openapi/integrator/token-requestor/server.yaml
@@ -96,31 +96,6 @@ components:
         cardholderAuthenticationData:
           $ref: '#/components/schemas/CardholderAuthenticationData'
 
-    VerifiedCardholderEnrolmentAuthenticationData:
-      type: object
-      required:
-        - authenticatedData
-        - nin
-        - authenticationReference
-        - authenticationCredentialsSet
-        - verificationDateTime
-      properties:
-        authenticatedData:
-          $ref: '#/components/schemas/EnrolmentAuthenticatedData'
-        nin:
-          $ref: '../components.yaml#/components/schemas/nin'
-        authenticationReference:
-          $ref: '../components.yaml#/components/schemas/authenticationReference'
-        authenticationCredentialsSet:
-          $ref: '../components.yaml#/components/schemas/AuthenticationCredentialsSet'
-        authenticationDateTime:
-          $ref: '../components.yaml#/components/schemas/authenticationDateTime'
-        verificationDateTime:
-          type: string
-          format: date-time
-        mostRecentTrustAnchorAuthentication:
-          $ref: '../components.yaml#/components/schemas/MostRecentTrustAnchorAuthentication'
-
     EnrolmentData:
       type: object
       required:
@@ -141,18 +116,7 @@ components:
         nin:
           $ref: '../components.yaml#/components/schemas/nin'
         mostRecentTrustAnchorAuthentication:
-          $ref: '../components.yaml#/components/schemas/MostRecentTrustAnchorAuthentication'
-
-    EnrolmentAuthenticatedData:
-      type: object
-      required:
-        - accountNumber
-        - tokenRequestorName
-      properties:
-        accountNumber:
-          $ref: '../components.yaml#/components/schemas/accountNumber'
-        tokenRequestorName:
-          type: string
+          $ref: '../components.yaml#/components/schemas/PermissionGrant'
 
     encryptedEnrolmentCardholderAuthenticationData:
       type: string

--- a/openapi/integrator/token-requestor/server.yaml
+++ b/openapi/integrator/token-requestor/server.yaml
@@ -114,12 +114,9 @@ components:
       type: object
       required:
         - nin
-        - mostRecentTrustAnchorAuthentication
       properties:
         nin:
           $ref: '../components.yaml#/components/schemas/nin'
-        mostRecentTrustAnchorAuthentication:
-          $ref: '../components.yaml#/components/schemas/PermissionGrant'
 
     encryptedEnrolmentCardholderAuthenticationData:
       type: string

--- a/openapi/integrator/wallet/client.yaml
+++ b/openapi/integrator/wallet/client.yaml
@@ -308,6 +308,3 @@ components:
 
     PaymentCardholderAuthenticationData:
       $ref: '../components.yaml#/components/schemas/PaymentCardholderAuthenticationData'
-
-    VerifiedCardholderPaymentAuthenticationData:
-      $ref: '../components.yaml#/components/schemas/VerifiedCardholderPaymentAuthenticationData'

--- a/openapi/integrator/wallet/server.yaml
+++ b/openapi/integrator/wallet/server.yaml
@@ -163,6 +163,8 @@ components:
       required:
         - amount
         - merchantName
+        - merchantDisplayName
+        - merchantReference
       properties:
         amount:
           $ref: '../components.yaml#/components/schemas/Amount'


### PR DESCRIPTION
The JWS payload objects `VerifiedCardholderPaymentAuthenticationData` and `VerifiedCardholderEnrolmentAuthenticationData` are both replaced with a new payload object `PermissionGrant`, which uses JWT Registered Claim Names. The new payload is also compatible with BankID.

Here's how the fields were mapped:
| Old | New | Comment |
| ---|---|---|
| authenticationDateTime | iat | |
| verificationDateTime | iat | |
| authenticationCredentialsSet.authenticationProviderId | iss | Using authentication provider's own (unique) issuer name instead of the NKOM name |
| authenticationCredentialsSet.trustedAnchorName | iss | Using trusted anchor authentication provider's own (unique) issuer name instead of the NKOM name |
| nin | sub | Value has added a prefix for identifier type which is `nnin:` |
| authenticationReference | permissionId | |
| authenticatedData | digest | Data is not included anymore, only a digest |
| mostRecentTrustAnchorAuthentication | N/A | Trusted anchor will not be supported for now |

The `digest` is computed from the following fields:
Payments:
* Payment id
* Amount
* Currency
* Creditor name (merchant's name)

Card enrolments:
* Account number (full)
* Merchant name (token requestor's name)
