### PR TITLE
API-M deployment fails

### DIFF
--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -152,7 +152,6 @@ components:
               * -1.50
               * 5877.78
           type: string
-          pattern: "-?[0-9]{1,14}(\\.[0-9]{1,3})?"
           example: "5877.78"
         currency:
           type: string


### PR DESCRIPTION
Failure due to a regexp pattern. Just removed that as we're not using it.