### PR TITLE
Versioning of endpoints are incorrectly specified

### DIFF
--- a/java/base-client/pom.xml
+++ b/java/base-client/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>base-client</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/java/base-client/src/main/java/module-info.java
+++ b/java/base-client/src/main/java/module-info.java
@@ -1,5 +1,7 @@
 module no.bankaxept.epayment.sdk.baseclient {
   uses no.bankaxept.epayment.client.base.spi.HttpClientProvider;
+  requires com.fasterxml.jackson.annotation;
+  requires com.fasterxml.jackson.databind;
   exports no.bankaxept.epayment.client.base;
   exports no.bankaxept.epayment.client.base.spi;
   exports no.bankaxept.epayment.client.base.http;

--- a/java/client-test/src/test/java/no/bankaxept/epayment/client/test/Verifier.java
+++ b/java/client-test/src/test/java/no/bankaxept/epayment/client/test/Verifier.java
@@ -8,7 +8,7 @@ import java.util.concurrent.Flow;
 public final class Verifier {
 
   public static <T> void verifyBadRequest(Flow.Publisher<T> publisher) {
-    verifyBadRequest(publisher, "Illegal value for parameter: ");
+    verifyBadRequest(publisher, "Missing field: messageId");
   }
 
   public static <T> void verifyBadRequest(Flow.Publisher<T> publisher, String messageStart) {

--- a/openapi/access-token/bankaxept.yaml
+++ b/openapi/access-token/bankaxept.yaml
@@ -5,13 +5,13 @@ info:
   description: BankAxept ePayment Access Token APIs
 
 servers:
-  - url: /bankaxept-epayment/access-token-api/v1
+  - url: https://epp.stoetest.cloud/access-token
 
 security:
   - ocpApimSubscriptionKey: []
 
 paths:
-  /accesstoken:
+  /v1/accesstoken:
     post:
       tags:
         - Client Authorization Service

--- a/openapi/access-token/bankaxept.yaml
+++ b/openapi/access-token/bankaxept.yaml
@@ -8,7 +8,7 @@ servers:
   - url: https://epp.stoetest.cloud/access-token
 
 security:
-  - ocpApimSubscriptionKey: []
+  - basicAuth: []
 
 paths:
   /v1/accesstoken:
@@ -92,10 +92,6 @@ components:
 
 
   securitySchemes:
-    ocpApimSubscriptionKey:
-      type: apiKey
-      in: header
-      name: Ocp-Apim-Subscription-Key
     basicAuth:
       type: http
       scheme: basic

--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -383,10 +383,6 @@ components:
       description: Server Error
 
   securitySchemes:
-    ocpApimSubscriptionKey:
-      type: apiKey
-      in: header
-      name: Ocp-Apim-Subscription-Key
     bearerAuth:
       type: http
       scheme: bearer

--- a/openapi/integrator/merchant/bankaxept.yaml
+++ b/openapi/integrator/merchant/bankaxept.yaml
@@ -8,7 +8,6 @@ servers:
   - url: https://epp.stoetest.cloud/merchant
 
 security:
-  - ocpApimSubscriptionKey: [ ]
   - bearerAuth: [ ]
 
 paths:

--- a/openapi/integrator/merchant/bankaxept.yaml
+++ b/openapi/integrator/merchant/bankaxept.yaml
@@ -5,14 +5,14 @@ info:
   description: BankAxept ePayment Merchant API - ePayment Platform side
 
 servers:
-  - url: /bankaxept-epayment/merchant-api/v1
+  - url: https://epp.stoetest.cloud/merchant
 
 security:
   - ocpApimSubscriptionKey: [ ]
   - bearerAuth: [ ]
 
 paths:
-  /payments:
+  /v1/payments:
     post:
       summary: Request a new payment
       description: >-
@@ -57,7 +57,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/messages/{messageId}:
+  /v1/payments/messages/{messageId}:
     delete:
       summary: Rollback a payment request
       operationId: rollbackPayment
@@ -84,7 +84,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/{paymentId}/captures:
+  /v1/payments/{paymentId}/captures:
     post:
       summary: Capture a payment
       description: |
@@ -119,7 +119,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/{paymentId}/cancellation:
+  /v1/payments/{paymentId}/cancellation:
     post:
       summary: Cancel a payment
       description: |
@@ -149,7 +149,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/{paymentId}/refunds:
+  /v1/payments/{paymentId}/refunds:
     post:
       summary: Refund a payment
       description: |
@@ -187,7 +187,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/{paymentId}/refunds/messages/{messageId}:
+  /v1/payments/{paymentId}/refunds/messages/{messageId}:
     delete:
       summary: Rollback a refund request
       operationId: rollbackRefund
@@ -215,7 +215,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /settlements/{merchantId}/{batchNumber}:
+  /v1/settlements/{merchantId}/{batchNumber}:
     put:
       summary: Cut off a settlement batch
       operationId: cutOff

--- a/openapi/integrator/merchant/partner.yaml
+++ b/openapi/integrator/merchant/partner.yaml
@@ -5,7 +5,7 @@ info:
   description: BankAxept ePayment Merchant API - Merchant Server side
 
 paths:
-  /payments:
+  /v1/payments:
     description: Response to a payment request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'
@@ -33,7 +33,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/captures:
+  /v1/payments/captures:
     description: Response to a capture request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'
@@ -61,7 +61,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/refunds:
+  /v1/payments/refunds:
     description: Response to a refund request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'
@@ -88,7 +88,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /settlements:
+  /v1/settlements:
     description: Response to a cut-off request
     parameters:
       - $ref: '../components.yaml#/components/parameters/correlationId'

--- a/openapi/integrator/token-requestor/bankaxept.yaml
+++ b/openapi/integrator/token-requestor/bankaxept.yaml
@@ -8,7 +8,6 @@ servers:
   - url: https://epp.stoetest.cloud/token-requestor
 
 security:
-  - ocpApimSubscriptionKey: [ ]
   - bearerAuth: [ ]
 
 paths:

--- a/openapi/integrator/token-requestor/bankaxept.yaml
+++ b/openapi/integrator/token-requestor/bankaxept.yaml
@@ -5,7 +5,7 @@ info:
   description: BankAxept ePayment Token Requestor APIs - ePayment Platform side
   
 servers:
-  - url: /bankaxept-epayment/token-requestor-api/v1
+  - url: https://epp.stoetest.cloud/token-requestor
 
 security:
   - ocpApimSubscriptionKey: [ ]
@@ -13,7 +13,7 @@ security:
 
 paths:
 
-  /payment-tokens:
+  /v1/payment-tokens:
     post:
       summary: Request a card enrolment
       operationId: enrolCard
@@ -41,7 +41,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payment-tokens/{tokenId}/deletion:
+  /v1/payment-tokens/{tokenId}/deletion:
     post:
       summary: Delete a token
       operationId: deleteToken

--- a/openapi/integrator/token-requestor/partner.yaml
+++ b/openapi/integrator/token-requestor/partner.yaml
@@ -5,7 +5,7 @@ info:
   description: BankAxept ePayment Token Requestor APIs - Token Requestor side
 
 paths:
-  /payment-tokens:
+  /v1/payment-tokens:
     description: EnrolCard callback
     post:
       operationId: addToken
@@ -32,7 +32,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /payment-tokens/suspensions:
+  /v1/payment-tokens/suspensions:
     description: Payment token suspension notification
     post:
       operationId: suspendToken
@@ -59,7 +59,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /payment-tokens/resumptions:
+  /v1/payment-tokens/resumptions:
     description: Payment token resumption notification
     post:
       operationId: resumeToken
@@ -86,7 +86,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /payment-tokens/{tokenRequestorReference}:
+  /v1/payment-tokens/{tokenRequestorReference}:
     description: Payment token deletion notification
     delete:
       operationId: deleteToken
@@ -108,7 +108,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /payment-tokens/expirations:
+  /v1/payment-tokens/expirations:
     description: Payment token expiry date extension notification
     post:
       operationId: extendExpiration

--- a/openapi/integrator/wallet/bankaxept.yaml
+++ b/openapi/integrator/wallet/bankaxept.yaml
@@ -4,7 +4,7 @@ info:
   title: BankAxept ePayment Wallet API - ePayment Platform
 
 servers:
-  - url: /bankaxept-epayment/wallet-api/v1
+  - url: https://epp.stoetest.cloud/wallet
 
 security:
   - ocpApimSubscriptionKey: [ ]
@@ -12,7 +12,7 @@ security:
 
 paths:
 
-  /payment-tokens:
+  /v1/payment-tokens:
     post:
       summary: Request a card enrolment
       operationId: enrolCard
@@ -40,7 +40,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payment-tokens/{tokenId}:
+  /v1/payment-tokens/{tokenId}:
     delete:
       summary: Delete a token
       operationId: deleteToken
@@ -63,7 +63,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments:
+  /v1/payments:
     post:
       summary: Request a new payment
       operationId: requestPayment
@@ -91,7 +91,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /payments/authentication-response:
+  /v1/payments/authentication-response:
     get:
       summary: Endpoint used by the authentication provider to provide the payment authentication response.
       operationId: completePaymentAuthentication
@@ -104,7 +104,7 @@ paths:
         '303':
           description: Redirect to a callback url registered to a merchant aggregator.
 
-  /payment-tokens/authentication-response:
+  /v1/payment-tokens/authentication-response:
     get:
       summary: Endpoint used by the authentication provider to provide the card enrolment authentication response.
       operationId: completeCardEnrolmentAuthentication

--- a/openapi/integrator/wallet/bankaxept.yaml
+++ b/openapi/integrator/wallet/bankaxept.yaml
@@ -7,7 +7,6 @@ servers:
   - url: https://epp.stoetest.cloud/wallet
 
 security:
-  - ocpApimSubscriptionKey: [ ]
   - bearerAuth: [ ]
 
 paths:

--- a/openapi/integrator/wallet/partner.yaml
+++ b/openapi/integrator/wallet/partner.yaml
@@ -4,7 +4,7 @@ info:
   title: BankAxept ePayment Wallet API - ePayment Platform
 
 paths:
-  /wallet/payment-tokens:
+  /v1/wallet/payment-tokens:
     description: EnrolCard callback
     post:
       operationId: addToken
@@ -31,7 +31,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /wallet/payment-tokens/authentication:
+  /v1/wallet/payment-tokens/authentication:
     description: Enrolment authentication
     post:
       operationId: authenticateEnrolment
@@ -59,7 +59,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /wallet/payment-tokens/authentication/complete:
+  /v1/wallet/payment-tokens/authentication/complete:
     description: When the authentication process has been completed, the user agent is redirected to this endpoint.
     get:
       operationId: completeEnrolmentAuthentication
@@ -81,7 +81,7 @@ paths:
           description: The partner is free to define its own responses.
 
 
-  /wallet/payment-tokens/suspensions:
+  /v1/wallet/payment-tokens/suspensions:
     description: Payment token suspension notification
     post:
       operationId: suspendToken
@@ -108,7 +108,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /wallet/payment-tokens/resumptions:
+  /v1/wallet/payment-tokens/resumptions:
     description: Payment token resumption notification
     post:
       operationId: resumeToken
@@ -135,7 +135,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /payment-tokens/{tokenId}:
+  /v1/wallet/payment-tokens/{tokenId}:
     description: Payment token deletion notification
     delete:
       operationId: deleteToken
@@ -157,7 +157,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /wallet/payment-tokens/expirations:
+  /v1/wallet/payment-tokens/expirations:
     description: Payment token expiry date extension notification
     post:
       operationId: extendExpiration
@@ -183,7 +183,7 @@ paths:
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
 
-  /wallet/payments:
+  /v1/wallet/payments:
     post:
       description: Response to a payment request
       operationId: addPayment
@@ -210,7 +210,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /wallet/payments/authentication:
+  /v1/wallet/payments/authentication:
     description: Payment authentication
     post:
       operationId: authenticatePayment
@@ -237,7 +237,7 @@ paths:
           $ref: '../components.yaml#/components/responses/500Error'
         '503':
           $ref: '../components.yaml#/components/responses/503Error'
-  /wallet/payments/authentication/complete:
+  /v1/wallet/payments/authentication/complete:
     description: When the authentication process has been completed, the user agent is redirected to this endpoint.
     get:
       operationId: completePaymentAuthentication


### PR DESCRIPTION
Added `/v1` prefix to all endpoints.

Side effects:
* Parsing problem details from HTTP 4xx responses and not including the whole body in the onError event.
* Set servers.url to point to new ePayment Platform test environment.
* Removed `security.ocpApimSubscriptionKey`, which is not used anymore.
* Added `security.basicAuth` to access-token-api.