### PR TITLE
No support for multiple wallet providers

### DIFF
--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -49,9 +49,13 @@ components:
     PaymentCardholderAuthenticationData:
       type: object
       required:
+        # - iat
+        - iss
         - paymentToken
         - verifiedCardholderAuthenticationSignedData
       properties:
+        iss:
+          $ref: '#/components/schemas/iss'
         paymentToken:
           $ref: '#/components/schemas/PaymentToken'
         verifiedCardholderAuthenticationSignedData:
@@ -252,6 +256,11 @@ components:
       type: string
       maxLength: 36
       example: "74313af1-e2cc-403f-85f1-6050725b01b6"
+    iss:
+      description: >-
+        A unique identifier for the issuer.
+      type: string
+      maxLength: 100
     messageId:
       description: >-
         A unique identifier that guarantees message idempotency.

--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -260,7 +260,7 @@ components:
       example: "74313af1-e2cc-403f-85f1-6050725b01b6"
     iss:
       description: >-
-        A unique identifier for the issuer.
+        Identifies the principal that issued the JWT.
       type: string
       maxLength: 100
     iat:

--- a/openapi/integrator/components.yaml
+++ b/openapi/integrator/components.yaml
@@ -49,13 +49,15 @@ components:
     PaymentCardholderAuthenticationData:
       type: object
       required:
-        # - iat
         - iss
+        - iat
         - paymentToken
         - verifiedCardholderAuthenticationSignedData
       properties:
         iss:
           $ref: '#/components/schemas/iss'
+        iat:
+          $ref: '#/components/schemas/iat'
         paymentToken:
           $ref: '#/components/schemas/PaymentToken'
         verifiedCardholderAuthenticationSignedData:
@@ -261,6 +263,13 @@ components:
         A unique identifier for the issuer.
       type: string
       maxLength: 100
+    iat:
+      description: >-
+        Identifies the time at which the JWT was issued.
+      type: integer
+      format: int64
+      minimum: 1600000000
+      maximum: 1800000000
     messageId:
       description: >-
         A unique identifier that guarantees message idempotency.

--- a/openapi/integrator/token-requestor/bankaxept.yaml
+++ b/openapi/integrator/token-requestor/bankaxept.yaml
@@ -86,9 +86,15 @@ components:
       type: object
       required:
         - enrolmentData
+        - iss
+        - iat
       properties:
         enrolmentData:
           $ref: '#/components/schemas/EnrolmentData'
+        iss:
+          $ref: '../components.yaml#/components/schemas/iss'
+        iat:
+          $ref: '../components.yaml#/components/schemas/iat'
         verifiedCardholderAuthenticationSignedData:
           $ref: '../components.yaml#/components/schemas/verifiedCardholderAuthenticationSignedData'
         cardholderAuthenticationData:

--- a/openapi/integrator/wallet/partner.yaml
+++ b/openapi/integrator/wallet/partner.yaml
@@ -364,6 +364,8 @@ components:
             - AuthenticationFailed
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
+        iss:
+          $ref: '../components.yaml#/components/schemas/iss'
         encryptedCardholderAuthenticationData:
           $ref: '../components.yaml#/components/schemas/encryptedPaymentCardholderAuthenticationData'
         merchantReference:

--- a/openapi/integrator/wallet/partner.yaml
+++ b/openapi/integrator/wallet/partner.yaml
@@ -364,8 +364,6 @@ components:
             - AuthenticationFailed
         messageId:
           $ref: '../components.yaml#/components/schemas/messageId'
-        iss:
-          $ref: '../components.yaml#/components/schemas/iss'
         encryptedCardholderAuthenticationData:
           $ref: '../components.yaml#/components/schemas/encryptedPaymentCardholderAuthenticationData'
         merchantReference:


### PR DESCRIPTION
- [x] This change solves a problem that's clearly defined in the linked issue.
- [x] The solution is sufficiently verified by automatic test coverage or by other means:

### No support for multiple wallet providers

Add fields for _iss_ and _iat_ to support multiple wallet providers. Decryption validates iss, and iat is added as nice to have. Both are defined in [RFC7519](https://www.rfc-editor.org/rfc/rfc7519).